### PR TITLE
Final steven timer

### DIFF
--- a/Assets/SceneManagement/Menu.unity
+++ b/Assets/SceneManagement/Menu.unity
@@ -892,11 +892,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7004250954060202134, guid: b98e17472161422409ce954e519a82b5, type: 3}
       propertyPath: totalTime
-      value: 300
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 7004250954060202134, guid: b98e17472161422409ce954e519a82b5, type: 3}
+      propertyPath: timeRemaining
+      value: 500
       objectReference: {fileID: 0}
     - target: {fileID: 7004250954060202134, guid: b98e17472161422409ce954e519a82b5, type: 3}
       propertyPath: countdownTimer
-      value: 1
+      value: 0.455
       objectReference: {fileID: 0}
     - target: {fileID: 7004250954060202134, guid: b98e17472161422409ce954e519a82b5, type: 3}
       propertyPath: driving1.m_SceneName

--- a/Assets/SceneManagement/Menu.unity
+++ b/Assets/SceneManagement/Menu.unity
@@ -245,7 +245,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 86c6556701af9e04380698b89f691b6e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  attenuationObject: {fileID: 0}
 --- !u!1 &610623316
 GameObject:
   m_ObjectHideFlags: 0
@@ -890,6 +889,14 @@ PrefabInstance:
     - target: {fileID: 7004250954060202129, guid: b98e17472161422409ce954e519a82b5, type: 3}
       propertyPath: m_Name
       value: GameManager
+      objectReference: {fileID: 0}
+    - target: {fileID: 7004250954060202134, guid: b98e17472161422409ce954e519a82b5, type: 3}
+      propertyPath: totalTime
+      value: 300
+      objectReference: {fileID: 0}
+    - target: {fileID: 7004250954060202134, guid: b98e17472161422409ce954e519a82b5, type: 3}
+      propertyPath: countdownTimer
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7004250954060202134, guid: b98e17472161422409ce954e519a82b5, type: 3}
       propertyPath: driving1.m_SceneName

--- a/Assets/SceneManagement/Objects/GameManager.cs
+++ b/Assets/SceneManagement/Objects/GameManager.cs
@@ -19,7 +19,7 @@ public class GameManager : MonoBehaviour
     public static GameManager instance = null;
     public static EventSystem eventSystemInstance = null;
 
-    // no need to edit countdownTimer or timeRemaining it will configure itselves
+    [Range(0.0f, 500.0f)]
     public float timeRemaining;
     public float totalTime;
     [Range(0.0f,1.0f)]

--- a/Assets/SceneManagement/Objects/GameManager.cs
+++ b/Assets/SceneManagement/Objects/GameManager.cs
@@ -13,10 +13,17 @@ using UnityEditor;
 
 public enum currGame { NONE, MENU, CUTSCENE, TACO_MAKING, DRIVING }
 
-public class GameManager : MonoBehaviour {
+public class GameManager : MonoBehaviour
+{
 
     public static GameManager instance = null;
     public static EventSystem eventSystemInstance = null;
+
+    // no need to edit countdownTimer or timeRemaining it will configure itselves
+    public float timeRemaining;
+    public float totalTime;
+    [Range(0.0f,1.0f)]
+    public float countdownTimer;
 
 
     [HideInInspector]
@@ -73,6 +80,8 @@ public class GameManager : MonoBehaviour {
         audioManager = GetComponentInChildren<AudioManager>();
         pauseManager = GetComponentInChildren<PauseManager>();
 
+        // set remaining time to total time initially
+        timeRemaining = totalTime;
     }
 
     private void OnEnable()
@@ -142,7 +151,8 @@ public class GameManager : MonoBehaviour {
         }
     }
 
-    public void Update() {
+    public void Update()
+    {
 
         // << TACO GAME MANAGER >>
         if (currGame == currGame.TACO_MAKING && tacoGameManager != null)
@@ -174,9 +184,25 @@ public class GameManager : MonoBehaviour {
                 LoadTacoMakingScene();
             }
         }
+
+        // is not cutscene or menu, countdown time
+        if (currGame != currGame.CUTSCENE && currGame != currGame.MENU)
+        {
+            if ((timeRemaining - Time.deltaTime) >= 0)
+            {
+                timeRemaining -= Time.deltaTime;
+            }
+            else
+            {
+                timeRemaining = 0;
+            }
+            countdownTimer = (1 - (timeRemaining / totalTime));
+            Debug.Log("countdown timer is:" + countdownTimer);
+        }
     }
 
-    public void LoadMenu() {
+    public void LoadMenu()
+    {
         currGame = currGame.MENU;
         currLevel = 1;
         cutsceneIndex = 0;
@@ -185,20 +211,24 @@ public class GameManager : MonoBehaviour {
     }
 
     // **** LOAD TACO MAKING SCENE ****
-    public void LoadTacoMakingScene(bool async = false) {
+    public void LoadTacoMakingScene(bool async = false)
+    {
 
         currGame = currGame.TACO_MAKING;
-        if(async){
+        if (async)
+        {
             StartCoroutine(ConcurrentLoadingCoroutine(tacoMakingScene));
         }
-        else{
+        else
+        {
             StartCoroutine(LoadingCoroutine(tacoMakingScene));
         }
         //audioManager.PlaySong(audioManager.tacoMusicPath);
     }
 
     // **** LOAD DRIVING SCENES ****
-    public void LoadDrivingScene(int levelNum) {
+    public void LoadDrivingScene(int levelNum)
+    {
         currGame = currGame.DRIVING;
 
         if (levelNum == 1)
@@ -236,7 +266,8 @@ public class GameManager : MonoBehaviour {
     [HideInInspector]
     public float loadProgress;
 
-    IEnumerator LoadingCoroutine(SceneObject scene) {
+    IEnumerator LoadingCoroutine(SceneObject scene)
+    {
         isLoadingScene = true;
         yield return null;
 
@@ -251,10 +282,12 @@ public class GameManager : MonoBehaviour {
         Debug.Log("Loading " + currScene + ":" + newScene.progress);
 
         //When the load is still in progress, output the Text and progress bar
-        while (!newScene.isDone) {
+        while (!newScene.isDone)
+        {
             loadProgress = newScene.progress;
 
-            if (newScene.progress >= 0.9f) {
+            if (newScene.progress >= 0.9f)
+            {
                 newScene.allowSceneActivation = true;
             }
             yield return new WaitForEndOfFrame();
@@ -263,8 +296,9 @@ public class GameManager : MonoBehaviour {
         SceneManager.UnloadSceneAsync(loadingScene);
         isLoadingScene = false;
     }
-    
-    IEnumerator ConcurrentLoadingCoroutine(SceneObject scene) {
+
+    IEnumerator ConcurrentLoadingCoroutine(SceneObject scene)
+    {
         isLoadingScene = true;
         yield return null;
 
@@ -278,10 +312,12 @@ public class GameManager : MonoBehaviour {
         Debug.Log("Loading " + currScene + ":" + newScene.progress);
 
         //When the load is still in progress, output the Text and progress bar
-        while (!newScene.isDone) {
+        while (!newScene.isDone)
+        {
             loadProgress = newScene.progress;
 
-            if (newScene.progress >= 0.9f) {
+            if (newScene.progress >= 0.9f)
+            {
                 newScene.allowSceneActivation = activateScene;
             }
             yield return new WaitForEndOfFrame();
@@ -293,7 +329,7 @@ public class GameManager : MonoBehaviour {
 
 
 
-#region >> SCENE OBJECT (( allows for drag / dropping scenes into inspector ))
+    #region >> SCENE OBJECT (( allows for drag / dropping scenes into inspector ))
     [System.Serializable]
     public class SceneObject
     {
@@ -311,7 +347,7 @@ public class GameManager : MonoBehaviour {
         }
     }
 
-#region SceneObjects
+    #region SceneObjects
 #if UNITY_EDITOR
             [CustomPropertyDrawer(typeof(SceneObject))]
             public class SceneObjectEditor : PropertyDrawer
@@ -362,8 +398,8 @@ public class GameManager : MonoBehaviour {
                 }
             }
 #endif
-#endregion
+    #endregion
 
 
-#endregion
+    #endregion
 }

--- a/Assets/SceneManagement/Objects/GameManager.cs
+++ b/Assets/SceneManagement/Objects/GameManager.cs
@@ -19,11 +19,12 @@ public class GameManager : MonoBehaviour
     public static GameManager instance = null;
     public static EventSystem eventSystemInstance = null;
 
-    [Range(0.0f, 500.0f)]
+    // slider for remaining time and timer from 0 to 1
+    [Range(0.0f, 1000.0f)]
     public float timeRemaining;
     public float totalTime;
     [Range(0.0f,1.0f)]
-    public float countdownTimer;
+    public float countdownTimer = 0;
 
 
     [HideInInspector]
@@ -197,8 +198,10 @@ public class GameManager : MonoBehaviour
                 timeRemaining = 0;
             }
             countdownTimer = (1 - (timeRemaining / totalTime));
-            Debug.Log("countdown timer is:" + countdownTimer);
+            //Debug.Log("countdown timer is:" + countdownTimer);
         }
+        calculateTime();
+        
     }
 
     public void LoadMenu()
@@ -325,6 +328,20 @@ public class GameManager : MonoBehaviour
 
         SceneManager.UnloadSceneAsync(thisScene);
         isLoadingScene = false;
+    }
+
+    public void calculateTime()
+    {
+        // in total minutes
+        float totalClockTime = (totalTime-timeRemaining+(totalTime*2/3))*(720/totalTime);
+        int clockHour = (int)(totalClockTime)/60;
+        if (clockHour > 12)
+        {
+            clockHour = clockHour - 12;
+        }
+        int clockMin = (int)(totalClockTime) % 60;
+        Debug.Log("current hour is: "+ clockHour);
+        Debug.Log("current minute is: " + clockMin);
     }
 
 

--- a/Assets/TextMesh Pro/Resources/Fonts & Materials/Singkong SDF.asset.meta
+++ b/Assets/TextMesh Pro/Resources/Fonts & Materials/Singkong SDF.asset.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 3f83eb9302a0235479ddc3d52cb60e21
-NativeFormatImporter:
-  externalObjects: {}
-  mainObjectFileID: 0
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
added timer that persists through scenes and pauses when in menu and cutscenes. totalTime is how much time is given to the player for the good ending. timeRemaining and countdownTimer will update itself depending on totalTime. They are set as visible for debugging purposes for the design team. timeRemaining and countdownTimer are both set as sliders to make it easy for the design team to assess it visually. Although sliding countdownTimer will have no effect, they can manipulate it via the timeRemaining timer which will change the countdownTimer in turn. I also added a clock which starts at 8 AM and ends at 8 PM. The speed of the passage of time will change depending on the totalTime given at the start. I don't know what assets the art team has so I just debug logged the hour and minute not seconds or am and pm. But if you want it, I can easily add it in. Just let me know.